### PR TITLE
Update service principal and SP group name input

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The service principals are granted `CAN_MANAGE` permissions on the created works
 **_NOTE:_** 
 1. This module is in preview so it is still experimental and subject to change. Feedback is welcome!
 2. The [Databricks providers](https://registry.terraform.io/providers/databricks/databricks/latest/docs) that are passed into the module must be configured with workspace admin permissions.
-3. The module assumes that the AWS Infrastructure Module has already been applied, namely that service principal groups with token usage permissions have been created with the default name `"mlops-service-principals"` or by specifying the `service_principal_group_name` field.
+3. The module assumes that the [MLOps AWS Infrastructure Module](https://registry.terraform.io/modules/databricks/mlops-aws-infrastructure/databricks/latest) has already been applied, namely that service principal groups with token usage permissions have been created with the default name `"mlops-service-principals"` or by specifying the `service_principal_group_name` field.
 4. The service principal tokens are created with a default expiration of 100 days (8640000 seconds), and the module will need to be re-applied after this time to refresh the tokens.
 
 ## Usage
@@ -33,7 +33,7 @@ module "mlops_aws_project" {
 }
 ```
 
-### Usage example with MLOps AWS Infrastructure Module
+### Usage example with [MLOps AWS Infrastructure Module](https://registry.terraform.io/modules/databricks/mlops-aws-infrastructure/databricks/latest)
 ```hcl
 provider "databricks" {
   alias = "dev" # Authenticate using preferred method as described in Databricks provider

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ resource "databricks_git_credential" "prod_git" {
 |------|-------------|------|---------|:--------:|
 |service_principal_name|The display name for the service principals.|string|N/A|yes|
 |project_directory_path|Path/Name of Databricks workspace directory to be created for the project. NOTE: The parent directories in the path must already be created.|string|N/A|yes|
-|service_principal_group_name|The name of the service principal group in the staging and prod workspace.|string|`"mlops-service-principals"`|no|
+|service_principal_group_name|The name of the service principal group in the staging and prod workspace. The created service principals will be added to this group.|string|`"mlops-service-principals"`|no|
 
 ## Outputs
 | Name | Description | Type | Sensitive |

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 data "databricks_group" "staging_sp_group" {
   provider     = databricks.staging
-  display_name = "mlops-service-principals"
+  display_name = var.service_principal_group_name
 }
 
 data "databricks_group" "prod_sp_group" {
   provider     = databricks.prod
-  display_name = "mlops-service-principals"
+  display_name = var.service_principal_group_name
 }
 
 module "staging_sp" {

--- a/modules/aws-service-principal/main.tf
+++ b/modules/aws-service-principal/main.tf
@@ -9,7 +9,8 @@ variable "group_name" {
 }
 
 resource "databricks_service_principal" "sp" {
-  display_name = var.display_name
+  display_name         = var.display_name
+  allow_cluster_create = true
 }
 
 data "databricks_group" "sp_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,6 @@ variable "project_directory_path" {
 
 variable "service_principal_group_name" {
   type        = string
-  description = "The name of the service principal group in the staging and prod workspace."
+  description = "The name of the service principal group in the staging and prod workspace. The created service principals will be added to this group."
   default     = "mlops-service-principals"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -7,3 +7,9 @@ variable "project_directory_path" {
   type        = string
   description = "Path/Name of Databricks workspace directory to be created for the project. NOTE: The parent directories in the path must already be created."
 }
+
+variable "service_principal_group_name" {
+  type        = string
+  description = "The name of the service principal group in the staging and prod workspace."
+  default     = "mlops-service-principals"
+}


### PR DESCRIPTION
1. Grant the created SPs in the project modules cluster creation entitlements
2. Add `group_name` as input
3. Show an example usage of the infra module together with the project somewhere in docs